### PR TITLE
Downloaded git_log.gz manually from Data_camp. This fixes #16

### DIFF
--- a/Exploring the Evolution of Linux/notebook.ipynb
+++ b/Exploring the Evolution of Linux/notebook.ipynb
@@ -1,1 +1,660 @@
-{"cells":[{"cell_type":"markdown","source":"## 1. Introduction\n<p><a href=\"https://commons.wikimedia.org/wiki/File:Tux.svg\">\n<img style=\"float: right;margin:5px 20px 5px 1px\" width=\"150px\" src=\"https://assets.datacamp.com/production/project_111/img/tux.png\" alt=\"Tux - the Linux mascot\">\n</a></p>\n<p>Version control repositories like CVS, Subversion or Git can be a real gold mine for software developers. They contain every change to the source code including the date (the \"when\"), the responsible developer (the \"who\"), as well as a little message that describes the intention (the \"what\") of a change.</p>\n<p>In this notebook, we will analyze the evolution of a very famous open-source project &ndash; the Linux kernel. The Linux kernel is the heart of some Linux distributions like Debian, Ubuntu or CentOS. Our dataset at hand contains the history of kernel development of almost 13 years (early 2005 - late 2017). We get some insights into the work of the development efforts by </p>\n<ul>\n<li>identifying the TOP 10 contributors and</li>\n<li>visualizing the commits over the years.</li>\n</ul>","metadata":{"editable":false,"run_control":{"frozen":true},"deletable":false,"dc":{"key":"4"},"tags":["context"]}},{"execution_count":15,"cell_type":"code","source":"# Printing the content of git_log_excerpt.csv\nwith open(\"datasets/git_log_excerpt.csv\") as file:\n    print(file.read())","metadata":{"trusted":true,"dc":{"key":"4"},"tags":["sample_code"]},"outputs":[{"output_type":"stream","text":"1502382966#Linus Torvalds\n1501368308#Max Gurtovoy\n1501625560#James Smart\n1501625559#James Smart\n1500568442#Martin Wilck\n1502273719#Xin Long\n1502278684#Nikolay Borisov\n1502238384#Girish Moodalbail\n1502228709#Florian Fainelli\n1502223836#Jon Paul Maloy\n","name":"stdout"}]},{"cell_type":"markdown","source":"## 2. Reading in the dataset\n<p>The dataset was created by using the command <code>git log --encoding=latin-1 --pretty=\"%at#%aN\"</code> in late 2017. The <code>latin-1</code> encoded text output was saved in a header-less CSV file. In this file, each row is a commit entry with the following information:</p>\n<ul>\n<li><code>timestamp</code>: the time of the commit as a UNIX timestamp in seconds since 1970-01-01 00:00:00 (Git log placeholder \"<code>%at</code>\")</li>\n<li><code>author</code>: the name of the author that performed the commit (Git log placeholder \"<code>%aN</code>\")</li>\n</ul>\n<p>The columns are separated by the number sign <code>#</code>. The complete dataset is in the <code>datasets/</code> directory. It is a <code>gz</code>-compressed csv file named <code>git_log.gz</code>.</p>","metadata":{"editable":false,"run_control":{"frozen":true},"deletable":false,"dc":{"key":"11"},"tags":["context"]}},{"execution_count":17,"cell_type":"code","source":"# Loading in the pandas module as 'pd'\nimport pandas as pd\n\n# Reading in the log file\ngit_log = pd.read_csv(\"datasets/git_log.gz\", sep='#', encoding='latin-1',\n                      header=None, names=[\"timestamp\", \"author\"])\n\n# Printing out the first 5 rows\ngit_log.head()","metadata":{"trusted":true,"dc":{"key":"11"},"tags":["sample_code"]},"outputs":[{"output_type":"execute_result","execution_count":17,"data":{"text/plain":"    timestamp          author\n0  1502826583  Linus Torvalds\n1  1501749089   Adrian Hunter\n2  1501749088   Adrian Hunter\n3  1501882480       Kees Cook\n4  1497271395       Rob Clark","text/html":"<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>timestamp</th>\n      <th>author</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>1502826583</td>\n      <td>Linus Torvalds</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1501749089</td>\n      <td>Adrian Hunter</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>1501749088</td>\n      <td>Adrian Hunter</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>1501882480</td>\n      <td>Kees Cook</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>1497271395</td>\n      <td>Rob Clark</td>\n    </tr>\n  </tbody>\n</table>\n</div>"},"metadata":{}}]},{"cell_type":"markdown","source":"## 3. Getting an overview\n<p>The dataset contains the information about every single code contribution (a \"commit\") to the Linux kernel over the last 13 years. We'll first take a look at the number of authors and their commits to the repository.</p>","metadata":{"editable":false,"run_control":{"frozen":true},"deletable":false,"dc":{"key":"18"},"tags":["context"]}},{"execution_count":19,"cell_type":"code","source":"# calculating number of commits\nnumber_of_commits = git_log.timestamp.count()\n\n# calculating number of authors\nnumber_of_authors = len(git_log.author.dropna().unique())\n\n# printing out the results\nprint(\"%s authors committed %s code changes.\" % (number_of_authors, number_of_commits))","metadata":{"trusted":true,"dc":{"key":"18"}},"outputs":[{"output_type":"stream","text":"17385 authors committed 699071 code changes.\n","name":"stdout"}]},{"cell_type":"markdown","source":"## 4. Finding the TOP 10 contributors\n<p>There are some very important people that changed the Linux kernel very often. To see if there are any bottlenecks, we take a look at the TOP 10 authors with the most commits.</p>","metadata":{"editable":false,"run_control":{"frozen":true},"deletable":false,"dc":{"key":"25"},"tags":["context"]}},{"execution_count":21,"cell_type":"code","source":"# Identifying the top 10 authors\ntop_10_authors = git_log.author.value_counts(dropna=True)[0:10]\n\n# Listing contents of 'top_10_authors'\ntop_10_authors","metadata":{"trusted":true,"dc":{"key":"25"},"tags":["sample_code"]},"outputs":[{"output_type":"execute_result","execution_count":21,"data":{"text/plain":"Linus Torvalds           23361\nDavid S. Miller           9106\nMark Brown                6802\nTakashi Iwai              6209\nAl Viro                   6006\nH Hartley Sweeten         5938\nIngo Molnar               5344\nMauro Carvalho Chehab     5204\nArnd Bergmann             4890\nGreg Kroah-Hartman        4580\nName: author, dtype: int64"},"metadata":{}}]},{"cell_type":"markdown","source":"## 5. Wrangling the data\n<p>For our analysis, we want to visualize the contributions over time. For this, we use the information in the <code>timestamp</code> column to create a time series-based column.</p>","metadata":{"editable":false,"run_control":{"frozen":true},"deletable":false,"dc":{"key":"32"},"tags":["context"]}},{"execution_count":23,"cell_type":"code","source":"# converting the timestamp column\ngit_log['timestamp'] = pd.to_datetime(git_log['timestamp'], unit='s')\n\n# summarizing the converted timestamp column\ngit_log.timestamp.describe()","metadata":{"trusted":true,"dc":{"key":"32"},"tags":["sample_code"]},"outputs":[{"output_type":"execute_result","execution_count":23,"data":{"text/plain":"count                  699071\nunique                 668448\ntop       2008-09-04 05:30:19\nfreq                       99\nfirst     1970-01-01 00:00:01\nlast      2037-04-25 08:08:26\nName: timestamp, dtype: object"},"metadata":{}}]},{"cell_type":"markdown","source":"## 6. Treating wrong timestamps\n<p>As we can see from the results above, some contributors had their operating system's time incorrectly set when they committed to the repository. We'll clean up the <code>timestamp</code> column by dropping the rows with the incorrect timestamps.</p>","metadata":{"editable":false,"run_control":{"frozen":true},"deletable":false,"dc":{"key":"39"},"tags":["context"]}},{"execution_count":25,"cell_type":"code","source":"# determining the first real commit timestamp\nfirst_commit_timestamp = git_log[git_log['author']=='Linus Torvalds'].timestamp.min()\nprint(\"Tovalds's first timestamp was at\", first_commit_timestamp)\n\n# determining the last sensible commit timestamp\nlast_commit_timestamp = git_log[git_log['timestamp'] < '2018'].timestamp.max()\nprint(\"The last timestamp before 2008 was at\", last_commit_timestamp)\n\n# filtering out wrong timestamps\ncorrected_log = git_log[(git_log['timestamp'] >= first_commit_timestamp) &\n                        (git_log['timestamp'] <= last_commit_timestamp)]\n\n# summarizing the corrected timestamp column\ncorrected_log['timestamp'].describe()","metadata":{"trusted":true,"dc":{"key":"39"}},"outputs":[{"output_type":"stream","text":"Tovalds's first timestamp was at 2005-04-16 22:20:36\nThe last timestamp before 2008 was at 2017-10-03 12:57:00\n","name":"stdout"},{"output_type":"execute_result","execution_count":25,"data":{"text/plain":"count                  698569\nunique                 667977\ntop       2008-09-04 05:30:19\nfreq                       99\nfirst     2005-04-16 22:20:36\nlast      2017-10-03 12:57:00\nName: timestamp, dtype: object"},"metadata":{}}]},{"cell_type":"markdown","source":"## 7. Grouping commits per year\n<p>To find out how the development activity has increased over time, we'll group the commits by year and count them up.</p>","metadata":{"editable":false,"run_control":{"frozen":true},"deletable":false,"dc":{"key":"46"},"tags":["context"]}},{"execution_count":27,"cell_type":"code","source":"# Counting the no. commits per year\ncommits_per_year = corrected_log.groupby(\n    pd.Grouper(\n        key='timestamp',\n        freq='AS'\n        )\n    ).count()\ncommits_per_year.columns = ['Commits']\n# Listing the first rows\ncommits_per_year.head()","metadata":{"trusted":true,"dc":{"key":"46"},"tags":["sample_code"]},"outputs":[{"output_type":"execute_result","execution_count":27,"data":{"text/plain":"            Commits\ntimestamp          \n2005-01-01    16229\n2006-01-01    29255\n2007-01-01    33759\n2008-01-01    48847\n2009-01-01    52572","text/html":"<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Commits</th>\n    </tr>\n    <tr>\n      <th>timestamp</th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>2005-01-01</th>\n      <td>16229</td>\n    </tr>\n    <tr>\n      <th>2006-01-01</th>\n      <td>29255</td>\n    </tr>\n    <tr>\n      <th>2007-01-01</th>\n      <td>33759</td>\n    </tr>\n    <tr>\n      <th>2008-01-01</th>\n      <td>48847</td>\n    </tr>\n    <tr>\n      <th>2009-01-01</th>\n      <td>52572</td>\n    </tr>\n  </tbody>\n</table>\n</div>"},"metadata":{}}]},{"cell_type":"markdown","source":"## 8. Visualizing the history of Linux\n<p>Finally, we'll make a plot out of these counts to better see how the development effort on Linux has increased over the the last few years. </p>","metadata":{"editable":false,"run_control":{"frozen":true},"deletable":false,"dc":{"key":"53"},"tags":["context"]}},{"execution_count":29,"cell_type":"code","source":"# Setting up plotting in Jupyter notebooks\n%matplotlib inline\n\ncommits_per_year['year_only'] = commits_per_year.index.year\n# plot the data\nax = commits_per_year.plot(x='year_only', kind='bar',\n                          legend=None, title=\"Annual commits\")\nax.set_xlabel('Year')\nax.set_ylabel('Commits')","metadata":{"trusted":true,"dc":{"key":"53"},"tags":["sample_code"]},"outputs":[{"output_type":"execute_result","execution_count":29,"data":{"text/plain":"<matplotlib.text.Text at 0x7f3ce513fb38>"},"metadata":{}},{"output_type":"display_data","data":{"text/plain":"<matplotlib.figure.Figure at 0x7f3cd91660f0>","image/png":"iVBORw0KGgoAAAANSUhEUgAAAagAAAEYCAYAAAAJeGK1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAIABJREFUeJzt3X2cXVV97/HPNwQEBEIQO4MECAIBpCgPEvBi5aBCAlqCt1cIPoQnFQULrb1eQttrkkur0NYaudyCtQgJVcNDpdCakpEmQ30ADJAAQkKiLSGJZCyEBASrPPzuH3sN2UxmMieTs/fss+f7fr3Oa/ZZ++G31pwz5zdr73XWVkRgZmZWNaOGuwJmZmb9cYIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyqxBJJ0haPdz12BqS5kv6+HDXw+rHCcpGNEndktZL2n6465LTVl9OjIhTI+JGAElnS/r+cNfJ6sEJykYsSfsB7wZeBU4b5urUhWizBGvV5QRlI9k04B7gBuCc/ApJ10u6WtI/S3pO0j2S9s+tf1XSBZJWpB7Y1bl1MyTdmHu+X9p+VHp+jqTH0nF/KulTzVZY0mGSuiQ9I+kpSdNT+Q6SZktaK2mNpK/09gp7TxtK+ryknrTNFEmnSHpc0tOSLutT/5sl3Zjq+JCkgyRNT/uvknRSbvtFks6TdAhwDfAuSc9LWp/Wnyrp0XSs1ZI+12x7bWRzgrKRbBrw98C3gEmS3txn/ZnADGB34GfAn/dZ/wHgaOAdwBmSTs6t69uLyD/vAU6NiN2Ac4GvSDpisMpK2gX4HjAf2As4EPjXtPpPgYnA21N9JqayXp3ADsBbUpu+DnwUOBJ4D/C/U4+y1weBOantS4EFZL2jtwCXA1/rW7+IWA58GrgnInaNiD3Sqr8DPpna+9vAwsHaagZOUDZCSXo3sC9wc0Q8CPwU+EifzW6LiAci4lXgm0DfJPKliHg+IlYDi/pZ36+I+JeIeCItfx/oAn6niV0/CDwVEbMj4jcR8UJELE7rPgLMiohnIuIZYBaQH7jwG+CLEfEKMA/YE5gdES9GxGPAY2SJrdf3I+Ku1PZb0vZX5PYfL2m3ZtqbYh8madeI2BgRS5vcz0Y4JygbqaYBXRHxbHr+beDsPtusyy2/COzSZ33PIOv7lU6t3ZNO0z0LnEKWAAazD1lPrj9vAZ7MPV+Vyno9E5tmhv5V+vmL3Ppf8fr69/RZ93Q/+zfVXuD3yHqbq9LpwOOa3M9GuNHDXQGzsknaETgDGCXpqVS8A7C7pMMj4pFtDPECsHPu+V652DsAtwIfA26PiFcl3UZ2+mwwq4GpA6xbC+wHLEvP9wN+vpX1boXNBkhExAPA6ZK2A34fuJms92q2Re5B2Uj0IeBl4FCy01rvSMs/IOtZbaulwHsk7SNpDDA9t26H9Hg6JadTgJP7O0g//hnolHRxGhSxi6SJad084E8l7SlpT+B/AzcOeKTi9ADjcgM0tpf0EUm7pdODzwOvDEO9rA05QdlINA34RkSsjYhf9D6Aq4GP9o62G8SAgyAi4i7gJuBhYDHwT7l1vwQuBm5Jo9ymArc3U+m070lkQ+LXASuARlr9Z8D9KeZDabnvoI6m6t+kGGB5IfAosE7SL9K6jwP/IWkD8Ck2v9Zn1i8VfcNCSX8InE/2XZNHyEYtvYXsP749gAeAj0fEy+n0x1yykVFPA2dGxJPpOJcB55H953tJRHSl8snAbLJke11EXFlog8zMrBSF9qAkvYXsnPNREfF2smteZwFXAl+OiAnABrIERvq5PiIOIks6f5GO8zayawaHkl1Q/htlRpH91zsJOAw4K30Xw8zM2lwZp/i2A94oaTSwE9mF2xOBf0jr5wCnp+Up6TlkF5Lfm5ZPA+ZFxMtpeO5Ksu95TARWRsSqiHiJrFc2pdjmmJlZGQpNUBHxc+DLZMNf1wIbgQeBDen7FQBrgL3T8t5kI5VIF1Q3StojX56sTWV9y/PHMjOzNlboMHNJu5P1aPYjS063AJO35hAtrIvnBzMzq6iI2OzzvuhTfO8H/j0i1qce0W3A8WTfN+mNPY6sR0T6uQ9A+s7EbhGxPl/eZ5+1vP77FPljbSYituoxY8aMrd5nWx6O156x6h6vzm3z77Ia8QZSdIJ6EjhO0o6SBLyPbAjqIuDDaZuz2TTM9g42fZv/w2yas+sOYGr67sf+ZHOQ/ZhsCO+BaTLOHciG7N5RcJvMzKwEhZ7ii4gfS7oVWAK8lH7+Ldlkl/MkXZ7Krku7XAfcKGkl8AzpW/MR8Zikm8nmC3sJuDCytPuKpM+SzWXWO8x8GWZm1vYKn+ooImaRTVyZ9x/Asf1s+2uy4eT9HedLwJf6Kb8TOHjba7q5RqNRxGEdr2ax6h6vzm0rO16d21ZEvMK/qFsVkmKktNXMrJ1IIoZhkISZmdmQOEGZmVklOUGZmVklOUGZmbWxzs7xSNrqR2fn+OGu+qA8SMLMrI1lXzEdymebtvgl2TJ5kISZWQnq3KMpm3tQZlZ7nZ3j6elZtdX7dXTsx7p1T2zVPmX3aOrcg3KCMrPaK/ND3Alq6/kUn5mZtRUnKDMzqyQnKDMzqyQnKDMzqyQnKDMzqyQnKDMzqyQnKDMzqyQnKDMzq6RCE5SkCZKWSHow/dwo6WJJYyV1SXpc0gJJY3L7XCVppaSlko7IlZ8taUXaZ1qu/ChJD6d1s4tsj5mZlafQBBURKyLiyIg4CjgaeAG4DZgO3BURBwMLgcsAJJ0CHBARBwEXANem8rHAF4BjyG4VPyOX1K4Bzo+ICcAESZOKbJOZmZWjzFN87wd+FhGrgSnAnFQ+Jz0n/ZwLEBH3AWMkdQCTgK6I2BgRG4AuYLKkTmDXiFic9p8LnF5Ka8xsyDyhqjVjdImxzgS+lZY7IqIHICLWpSQEsDewOrfPmlTWt3xtrnxNP9ubWYVlE7du/TxwPT2bTddmNVZKgpK0PXAacGkq6vvOHOid2tJ348yZM19bbjQaNBqNVh7ezMya0N3dTXd396DblTKbuaTTgAsjYnJ6vgxoRERPOk23KCIOlXRtWr4pbbccOAE4MW3/6VR+LbAIuLt331Q+FTghIj7TTx08m7lZRdR5xu86t60owz2b+VnAt3PP7wDOScvnALfnyqcBSDoO2JBOBS4ATpI0Jg2YOAlYEBHrgI2SJip7labljmVmZm2s8B6UpJ2BVcBbI+L5VLYHcDOwT1p3Rhr8gKSrgclkI/7OjYgHU/k5wJ+Q/avwZxExN5UfDdwA7AjMj4hLBqiHe1BmFVHnXkad21YU37DQCcqsMur8IV7nthVluE/xmZmZbRUnKDMzqyQnKDMzqyQnKDMzqyQnKDMzqyQnKDMzqyQnKDMzqyQnKDPz7OJWSf6irpnV/sul/qJu6+IVwV/UNTOztuIEZWZmleQEZWZmleQEZWZmleQEZWZmleQEZWZmleQEZWZmleQEZWZmlVR4gpI0RtItkpZJelTSsZLGSuqS9LikBZLG5La/StJKSUslHZErP1vSirTPtFz5UZIeTutmF90eMzMrRxk9qK8C8yPiUOAdwHJgOnBXRBwMLAQuA5B0CnBARBwEXABcm8rHAl8AjgGOBWbkkto1wPkRMQGYIGlSCW0yM7OCFZqgJO0G/E5EXA8QES9HxEZgCjAnbTYnPSf9nJu2vQ8YI6kDmAR0RcTGiNgAdAGTJXUCu0bE4rT/XOD0IttkZmblKLoHtT/wtKTrJT0o6W8l7Qx0REQPQESsAzrS9nsDq3P7r0llfcvX5srX9LO9mZm1udElHP8o4KKIuF/SV8hO7/WdoXCgGQs3mzxwW8ycOfO15UajQaPRaOXhzcysCd3d3XR3dw+6XaGzmafTc/dExFvT83eTJagDgEZE9KTTdIsi4lBJ16blm9L2y4ETgBPT9p9O5dcCi4C7e/dN5VOBEyLiM/3UxbOZmw2g7jNwezbz1sUrwrDMZp5O462WNCEVvQ94FLgDOCeVnQPcnpbvAKYBSDoO2JCOsQA4KY0IHAucBCxIpwc3Spqo7FWaljuWmZm1saJP8QFcDHxT0vbAvwPnAtsBN0s6D1gFnAEQEfMlnSrpp8ALaVsi4llJlwP3k/2rMCsNlgC4CLgB2JFstOCdJbTJzMwK5hsWmlntT0v5FF/r4hXBNyw0M7O24gRlZmaV5ARlZmaV5ARlZmaV5ARlVlGdneORtNWPzs7xw111s5bwKD6zivLIs/aMV+e2FcWj+MzMrK04QZmZWSU5QZmZWSU5QZmZWSU5QZmZWSU5QZmZWSU5QZmZWSU5QZmZWSU5QVnb8kwLZvXmmSSsbdXhG/Rb4tkP2jNendtWFM8kYWZmbaXwBCXpCUkPSVoi6cepbKykLkmPS1ogaUxu+6skrZS0VNIRufKzJa1I+0zLlR8l6eG0bnbR7TEzs3KU0YN6FWhExJERMTGVTQfuioiDgYXAZQCSTgEOiIiDgAuAa1P5WOALwDHAscCMXFK7Bjg/IiYAEyRNKqFNZmZWsDISlPqJMwWYk5bnpOe95XMBIuI+YIykDmAS0BURGyNiA9AFTJbUCewaEYvT/nOB0wtriZmZlaaMBBXAAkmLJX0ilXVERA9ARKwDOlL53sDq3L5rUlnf8rW58jX9bG9mZm1udAkxjo+IpyS9GeiS9DibDzkZaCjJZqM6tsXMmTNfW240GjQajVYe3szMmtDd3U13d/eg25U6zFzSDOCXwCfIrkv1pNN0iyLiUEnXpuWb0vbLgROAE9P2n07l1wKLgLt7903lU4ETIuIz/cT2MPOaKXt4bWfneHp6Vm31fh0d+7Fu3RNbvZ+HRrdnvDq3rSjDMsxc0s6SdknLbwROBh4B7gDOSZudA9yelu8ApqXtjwM2pFOBC4CTJI1JAyZOAhak04MbJU1U9ipNyx3LrKWy5BRb/RhKUjOz4k/xdQC3SYoU65sR0SXpfuBmSecBq4AzACJivqRTJf0UeAE4N5U/K+ly4H6yv/pZabAEwEXADcCOwPyIuLPgNtkWDKWXMdQehpnVm2eSsJYa2umG9ji1Ued4dW5b2fHq3LaieCYJMzNrK05QZmZWSU0lKEnHp0EOSPqYpL+WtF+xVTMzs6op8y4CzfagrgFelPQO4I+An5FmfDAzs5GjzNGszSaol9MIgynA1RHx/4BdtzqamZlZk5odZv68pMuAjwHvkTQK2L64apmZ2UjXbA/qTODXZLOGrwPGAX9ZWK3MzGzEa7YH9YcRcWnvk4h4UtJhBdXJzMys6R7USf2UndLKipiZmeVtsQcl6TPAhcBbJT2cW7Ur8KMiK2ZmZiPbFqc6SnetHQt8iewuuL2ej4j1BdetpTzVUTk81VF7xqtz28qOV+e2FRVvoKmOBktQu0XEc5L26G99OyUpJ6hyOEG1Z7w6t63seHVuW1HxBkpQgw2S+BbwQeCBVKP8AQJ46xBqaWZmNijPZm4t5R5Ue8arc9vKjlfnthUVb6g9qPwB3g6Mz+8TEd/Z+kqamZkNrqkEJekbwNuBR4FXU3EATlBmZlaIZntQx0XE2wqtiZmZWU6zX9S9R9KQE5SkUZIelHRHej5e0r2SVkj6tqTRqXwHSfMkrZR0j6R9c8e4LJUvk3RyrnyypOXpWJduHt3MzNpRswlqLlmSelzSw5Ie6fPF3cFcAjyWe34l8OWImABsAM5P5ecD6yPiIGA28BcAKTmeARxKNoPF3ygzCrgamAQcBpwl6ZCtqJeZmVVUswnqOuDjwGTgd8mGnv9uMztKGgecCvxdrvi9wD+k5TnA6Wl5SnoOcGvaDuA0YF5EvBwRTwArgYnpsTIiVkXES8C8dAwzM2tzzV6D+s+IuGOIMb4CfB4YAyDpTcCzEdE72GINsHda3htYDRARr0jamL4kvDdwT+6Ya1OZerfPHWviEOtpZmYV0myCWiLpW8A/kd12Axh8mLmkDwA9EbFUUiO/qsm4zW7XlJkzZ7623Gg0aDQarTy8mZk1obu7m+7u7kG3azZB7USWmE7OlTUzzPx44DRJp6Zj7Ap8FRgjaVTqRY0j6xGRfu4D/FzSdsBuEbFeUm95r959BOzbT3m/8gnKzMyGR98OwqxZs/rdrrSZJCSdAPxRRJwm6SbgOxFxk6RrgIci4lpJFwK/HREXSpoKnB4RU9MgiW8Cx5Kd2vsecBDZNbTHgfcBTwE/Bs6KiGX9xPdMEiXwTBLtGa/ObSs7Xp3bVlS8bZpJQtL+wO+z+UwSpw2hlpDNjD5P0uXAErJBGKSfN0paCTwDTE1xHpN0M9lIwJeAC1O2eUXSZ4EusmR1XX/JyczM2k9TPShJD5Elj0fYNJMEEXF3cVVrLfegyuEeVHvGq3Pbyo5X57YVFW9b5+L7r4i4agg1MjMzG5Jme1AfIbvm08XrR/E9WFzVWss9qHK4B9We8erctrLj1bltRcXb1h7U4WRf1H0vr58s9r0D7mFmZrYNmk1QHwbeGhG/KbIyZmZmvZqd6ugnwO5FVsTMzCyv2R7U7sBySYt5/TWooQ4zNzMz26JmE9SMQmthZmbWR1MJKiLultQBHJOKfhwRvyiuWmZmNtI1dQ1K0hlk0wh9mOy+TPdJ+h9FVszMzEa2Zk/x/QlwTG+vSdKbgbvI7tlkZmbWcs2O4hvV55TeM1uxr5mZ2VZrNsncKWmBpHMknQN8F5hfXLWsVTo7xyNpqx+dneOHu+pmNsJtcaojSQcCHRHxQ0n/HXh3WrUB+GZE/KyEOrbESJ3qqD2mQanOlCsjNV6d21Z2vDq3rah4A011NFiC+mfgsoh4pE/54cAXI+J3h1DLYeEEtdV7OkGNoHh1blvZ8erctqLiDZSgBjvF19E3OQGksvFDqKGZmVlTBktQW5reaKdWVsTMzCxvsAR1v6RP9i2U9AnggWKqZGZmNniC+gPgXEndkr6cHncD5wOXDHZwSW+QdJ+kJZIekTQjlY+XdK+kFZK+LWl0Kt9B0jxJKyXdI2nf3LEuS+XLJJ2cK58saXk61qVD+SWYmVn1NHvDwhOB305PH42IhU0HkHaOiBclbQf8kCyxfQ64NSJukXQNsDQivibpM8DhEXGhpDOBD0XEVElvA75JNtXSOLIvCR8ECFgBvA/4ObAYmBoRy/uphwdJbN2eHiQxguLVuW1lx6tz24qKt003LIyIRcCiIdSIiHgxLb4hxQvgROCsVD6HbDLarwFT2DQx7a3A/03LpwHzIuJl4AlJK4GJZAlqZUSsApA0Lx1jswRlZmbtpfDZICSNkrQEWAd8D/gZsCEieu/MuwbYOy3vDawGiIhXgI2S9siXJ2tTWd/y/LHMzKyNNTsX35ClRHSkpN2A24BDtmL3zbp822LmzJmvLTcaDRqNRisPb2ZmTeju7qa7u3vQ7QpPUL0i4jlJ3cC7gN0ljUrJaxxZj4j0cx/g5+ma1W4RsV5Sb3mv3n0E7NtPeb/yCcrMzIZH3w7CrFmz+t2u0FN8kvaUNCYt7wScBDxGdj3rw2mzs4Hb0/Id6Tlp/cJc+dQ0ym9/4ECy238sBg6UtJ+kHYCpadvK8tx4ZmbNKboHtRcwR9IosmR4U0TMl7QMmCfpcmAJcF3a/jrgxjQI4hmyhENEPCbpZrLk9hJwYRqS94qkzwJd6fjXRcSygtu0TXp6VjGUETA9PS0922lmVnlNDTOvg6oMM6/DkNDWx6tz29ojXp3bVna8OretqHhDnYvPzMxsWDhBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJTlBmZlZJRV9y/dxkhZKelTSI5IuTuVjJXVJelzSgt7bwqd1V0laKWmppCNy5WdLWpH2mZYrP0rSw2nd7CLbY2Zm5Sm6B/Uy8LmIOAx4F3CRpEOA6cBdEXEwsBC4DEDSKcABEXEQcAFwbSofC3wBOAY4FpiRS2rXAOdHxARggqRJBbfJzMxKUGiCioh1EbE0Lf8SWAaMA6YAc9Jmc9Jz0s+5afv7gDGSOoBJQFdEbIyIDUAXMFlSJ7BrRCxO+88FTi+yTWZmVo7SrkFJGg8cAdwLdERED2RJDOhIm+0NrM7ttiaV9S1fmytf08/2ZmbW5kpJUJJ2AW4FLkk9qeizSd/nr+1aaMXMzKyyRhcdQNJosuR0Y0Tcnop7JHVERE86TfeLVL4W2Ce3+7hUthZo9ClftIXt+zVz5szXlhuNBo1GY6BNzcysIN3d3XR3dw+6nSIG6ry0hqS5wNMR8blc2ZXA+oi4UtJ0YPeImC7pVOCiiPiApOOA2RFxXBokcT9wFFmv737g6IjYIOle4GJgMfBd4KqIuLOfekTRbW2GJAbuMG5xT4ZS//aIV+e2tUe8Oret7Hh1bltR8SQREZudMSu0ByXpeOCjwCOSlpC16o+BK4GbJZ0HrALOAIiI+ZJOlfRT4AXg3FT+rKTLyRJTALPSYAmAi4AbgB2B+f0lJzMzaz+F96Cqwj2oKserc9vaI16d21Z2vDq3rah4A/WgPJOEmZlVkhOUmZlVkhOUmZlVkhOUmZlVkhOUmZlV0ohPUJ2d45G01Y/OzvHDXXUzs1ob8cPM6zBEs/3j1blt7RGvzm0rO16d21ZUPA8zNzOztuIEZWZmleQEZWZmleQEZWZmleQEZWZmleQEZWZmleQEZWZmleQEZWZmleQEZWZmleQEZWZmlVRogpJ0naQeSQ/nysZK6pL0uKQFksbk1l0laaWkpZKOyJWfLWlF2mdarvwoSQ+ndbOLbIuZmZWr6B7U9cCkPmXTgbsi4mBgIXAZgKRTgAMi4iDgAuDaVD4W+AJwDHAsMCOX1K4Bzo+ICcAESX1jmZlZmyo0QUXED4Bn+xRPAeak5TnpeW/53LTffcAYSR1kCa4rIjZGxAagC5gsqRPYNSIWp/3nAqcX1hgzMyvVcFyD+q2I6AGIiHVARyrfG1id225NKutbvjZXvqaf7c3MrAaqMEhioHnbN5t63czMRo7RwxCzR1JHRPSk03S/SOVrgX1y241LZWuBRp/yRVvYfkAzZ858bbnRaNBoNAbc1szMitHd3U13d/eg2xV+w0JJ44F/iojD0/MrgfURcaWk6cDuETFd0qnARRHxAUnHAbMj4rg0SOJ+4CiyHt/9wNERsUHSvcDFwGLgu8BVEXHnAPXwDQsrG6/ObWuPeHVuW9nx6ty2ouINdMPCQntQkr5F1vt5k6QngRnAFcAtks4DVgFnAETEfEmnSvop8AJwbip/VtLlZIkpgFlpsATARcANwI7A/IGSk5mZtR/f8r0G/320f7w6t6094tW5bWXHq3PbiornW76bmVlbcYIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKcoIyM7NKqkWCkjRZ0nJJKyRd2rojd7fuUI5XcrwyY9U9Xpmx6h6vzFjtH6/tE5SkUcDVwCTgMOAsSYe05ujdrTmM4w1DvDJj1T1embHqHq/MWO0fr+0TFDARWBkRqyLiJWAeMGWY62RmZtuoDglqb2B17vmaVGZmZm1METHcddgmkn4PmBQRn0rPPwZMjIiL+2zX3g01M6uxiFDfstHDUZEWWwvsm3s+LpW9Tn+NNzOz6qrDKb7FwIGS9pO0AzAVuGOY62RmZtuo7XtQEfGKpM8CXWQJ97qIWDbM1TIzs23U9tegzMysnupwis/MzGrICcrMzCqp7a9BFUXS/sCRwGMRsbyA4+8L/CIi/kuSgHOAo4DHgK9HxMstjnca0BUR/9XK424h3nuAnoh4XNLxwLuAZRHx3YLi7QJMBvYBXgFWkLX31YLiHUL2hfDe79ytBe7w9c+tJ2kiEBGxWNLbyF7H5RExv4TYcyNiWtFxbGh8DSqR9I8RcXpangLMJpu3478BX4qIG1oc7ydk39d6UdKVwAHAPwLvBYiI81oc71fAC8C/AN8GFkTEK62MkYs1m2yGj9HAAuB9Ke4JwJKI+HyL450B/E/gYeBE4EdkZwcOBz4aEY+0ON6lwFlks5asScXjyEaQzouIK1oZbwv1ODciri/guIeQJd77IuKXufLJEXFni2PNAE4he698DzgWWAScRPYe/fMWxuo7uldk75eFABFxWqtiDRD/3WR/Fz+JiK4Cjn8s2T+Bz0naCZjOpn96vxgRG1sc72LgtohYPejGQxURfmRJeklu+UfA/ml5T+ChAuI9llt+ABiVe15EvCXAWOCTwL8CPcC1wAkFxHqU7I9/Z+BZYOdUvj3ZH2er4z2ci7En2QcbwNuBHxUQbwWwfT/lO5BNu1XWe/bJAo55MfA42T9LTwBTcuseLCDeI8B26b3yHLBbKt8JeLjFsR4E/h5okP2z1ACeSssnFNC2H+eWPwksBWYAPwSmFxDvUWB0Wv5bsn+y351ifqeAeBuBnwPfBy4E3tzqGD7Ft0m+Kzk6Iv4DICKellTEaaLVkt4bEQvJPgj2AVZJelMBsSA7hfIs8HXg65I6gTOAKySNi4h9Whwrcr+33t/tqxRz3VPAr9LyC8BvpUo8LGm3AuK9CrwFWNWnfK+0rmUkPTzQKqCjlbGSTwJHR8QvJY0HbpU0PiK+mmK22suR9eRflPSziHgOICJ+VcDf3TuBS4A/AT4fEUsl/Soi7m5xnF7b55Y/BZwUEf8p6a+Ae4FW97RHxaZLA++MiKPS8g8kLW1xLIB/B44G3g+cCcyS9ADZGZrvRMTz2xrACWqTd0h6juyP8A2S9oqIp9KXf7crIN4ngLmSZpL9J7I0vYl2Bz5XQLzXfbhExDrgKuAqSfu1ONZ3JX0f2BH4O+BmSfeS/af6by2OBTAfuFPSv5Fdv7gFQNIeFPOh+gfAv0payaZ5IPcFDgQ+2+JYHWQz9T/bp1xkPf1WGxXptF5EPCGpQZak9qOY3+VvJO0cES+SfdgBIGkMLU72kV2P/IqkW9LPHor9DBwlaSzZP2WKiP9M9XhBUkuvMSc/yZ32fUjSOyPifkkTgJcKiBe5kXYcAAAF8ElEQVTpd9oFdEnanux07VnAXwFv3tYAvgY1CEm7A4dGxD0FHf9QYALZH8oaYHEUcGFfUiMiult93C3EexfZG/heSQcAHwKeBG4tqH2nAm8jOz36vVQ2iuxU3K8LiDeK7HpCfpDE4mjxdT1J1wHXR8QP+ln3rYj4SIvjLQQ+FxFLc2WjgW+QXc9r6T9rkt7Q3+sjaU9gr2jx9cM+MT4AHB8Rf1zQ8Z8gS7IiO4twfPqndxfgBxFxRIvjjQG+CvwO8DTZ9afV6XFxRDzU4nhLIuLIAdb1/tOxbTGcoF5PUge5D52I6HG86scajngD1GGXyA0saDeSxpGddlvXz7rjI+KHJdaltN9lybF2Bjp6LyMUcPzdgP1J//QW9XcgaUJErCji2K/FcILKSDoSuAYYw6bJZscBG4DPRMSSFsc7gmyQQn/xLoyIB9s1Xp3b1kRdnoyIfQffsiWxSk2GwxCvzN9labFSvLq/di2J52tQm1wPXBAR9+ULJR0H3AC8o8XxbthCvOvbPF6ZsUqPJ2mga4QCdmllrEE8xutn8m+7eGX+Liv0ukENXrsy4jlBbfLGvh9wAOkayhsdr7KxhiPeF4G/BPq70N3SUYplf6gOw4d4ab/LkmPV/rUrI54T1Cb/Ium7wFw2jczaB5gGtPTLiSMgXp3bBtn3af4xIh7ou0LSJ1ocq9QP1WGIV+bvssxYUP/XrvB4vgaVI+kU+p++ppApV+ocr+ZtOxhY3ztsuM+6jlZelJb0I+D3B/hQXd3i768NR7wyf5elxUrHrPtrV3g8JyizChuGD9VS49VZ3V+7MuJ5NvNE0hhJV0haJmm9pGfS8hXpu1COV8FYwxxvedHxIuLx/j4A0rqWJ4uy45X5uywzFtT/tSsjnhPUJjeTfVv/xIjYIyLeRDaR5Ia0zvGqGWs44zX6xHu21fHK/lAtOx4l/i5LjlX7166UeNHiyf3a9QE8PpR1jjey2jYMv8sFwKVAZ66sM5V1FdC2suPV+X1Z99eu8HjuQW2yStL/UjYbAZCdR1V2a4UippOvc7w6t63seOMj4srIzewQEesi4kqg1XMoDke8Or8v6/7aFR7PCWqTM4E3AXdLelbSerL7Qe1BNuu341UzVt3j1Tn5Qr3fl3V/7YqP1+puXzs/gEPIpo7fpU/5ZMerbqw6xyO7h9eVwHKyayXrgWWpbI8C2lVqvLJfu5Jj1fq1KyNey99s7fqg/Bu11TZends2TPFqmXzL/l2W/brV/bUrI17LK9yuD7I7e+6SlscD9wOXpOdLHK+aseoebwQk3zq/L+v+2hUez1MdbVL2jdrqHK/ObSs7Xtl3uC07Xp3fl3V/7QqP50ESm/Qou20DAOmN/EFgT+Bwx6tsrLrHe92HKtAATpH015SQMEqIV+f3Zd1fu+Ljtbrb164PsvsHdQ6w7njHq2asuscDFgJH9CkbTTYx7isFtK3seHV+X9b9tSs8nufiM6swlXyH27Lj1VndX7sy4jlBmZlZJfkalJmZVZITlJmZVZITlJmZVZITlFlFSPq+pMm55x+WVMgdiM3agQdJmFWEpMOAW4AjgB2AB4GTI/uOyVCPuV1EvNKaGpqVywnKrEIkXQG8CLwReC4i/lzSNOAiYHvgRxHx2bTt14AjgZ2AmyLiz1L5auDvgZOBL0bEP5TfErNt56mOzKrl/5D1nH4NvDP1qj4EvCsiXpX0NUlTI2IecGlEbJC0HbBI0q0RsTwdpycijh6eJpi1hhOUWYVExIuSbgKej4iXJL0feCdwvyQBOwJPps0/Kuk8sr/jvYC3kd36AOCmkqtu1nJOUGbV82p6QDan2TciYkZ+A0kHks0m/c6IeF7SjWTJq9cLpdTUrEAexWdWbXcBZ0h6E4CkPSTtA+wGPAf8UtJewKRhrKNZIdyDMquwiPiJpFnAXZJGAb8BPh0RD0haRnYH01XAD/K7DUNVzVrOo/jMzKySfIrPzMwqyQnKzMwqyQnKzMwqyQnKzMwqyQnKzMwqyQnKzMwqyQnKzMwq6f8DAvPhMq75vt0AAAAASUVORK5CYII=\n"},"metadata":{}}]},{"cell_type":"markdown","source":"## 9.  Conclusion\n<p>Thanks to the solid foundation and caretaking of Linux Torvalds, many other developers are now able to contribute to the Linux kernel as well. There is no decrease of development activity at sight!</p>","metadata":{"editable":false,"run_control":{"frozen":true},"deletable":false,"dc":{"key":"60"},"tags":["context"]}},{"execution_count":31,"cell_type":"code","source":"# calculating or setting the year with the most commits to Linux\nyear_with_most_commits = commits_per_year['Commits'].idxmax().year","metadata":{"trusted":true,"dc":{"key":"60"},"tags":["sample_code"]},"outputs":[]}],"nbformat_minor":2,"nbformat":4,"metadata":{"language_info":{"mimetype":"text/x-python","codemirror_mode":{"version":3,"name":"ipython"},"version":"3.5.2","nbconvert_exporter":"python","file_extension":".py","name":"python","pygments_lexer":"ipython3"},"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"}}}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dc": {
+     "key": "4"
+    },
+    "deletable": false,
+    "editable": false,
+    "run_control": {
+     "frozen": true
+    },
+    "tags": [
+     "context"
+    ]
+   },
+   "source": [
+    "## 1. Introduction\n",
+    "<p><a href=\"https://commons.wikimedia.org/wiki/File:Tux.svg\">\n",
+    "<img style=\"float: right;margin:5px 20px 5px 1px\" width=\"150px\" src=\"https://assets.datacamp.com/production/project_111/img/tux.png\" alt=\"Tux - the Linux mascot\">\n",
+    "</a></p>\n",
+    "<p>Version control repositories like CVS, Subversion or Git can be a real gold mine for software developers. They contain every change to the source code including the date (the \"when\"), the responsible developer (the \"who\"), as well as a little message that describes the intention (the \"what\") of a change.</p>\n",
+    "<p>In this notebook, we will analyze the evolution of a very famous open-source project &ndash; the Linux kernel. The Linux kernel is the heart of some Linux distributions like Debian, Ubuntu or CentOS. Our dataset at hand contains the history of kernel development of almost 13 years (early 2005 - late 2017). We get some insights into the work of the development efforts by </p>\n",
+    "<ul>\n",
+    "<li>identifying the TOP 10 contributors and</li>\n",
+    "<li>visualizing the commits over the years.</li>\n",
+    "</ul>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "dc": {
+     "key": "4"
+    },
+    "tags": [
+     "sample_code"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1502382966#Linus Torvalds\n",
+      "1501368308#Max Gurtovoy\n",
+      "1501625560#James Smart\n",
+      "1501625559#James Smart\n",
+      "1500568442#Martin Wilck\n",
+      "1502273719#Xin Long\n",
+      "1502278684#Nikolay Borisov\n",
+      "1502238384#Girish Moodalbail\n",
+      "1502228709#Florian Fainelli\n",
+      "1502223836#Jon Paul Maloy\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Printing the content of git_log_excerpt.csv\n",
+    "with open(\"datasets/git_log_excerpt.csv\") as file:\n",
+    "    print(file.read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dc": {
+     "key": "11"
+    },
+    "deletable": false,
+    "editable": false,
+    "run_control": {
+     "frozen": true
+    },
+    "tags": [
+     "context"
+    ]
+   },
+   "source": [
+    "## 2. Reading in the dataset\n",
+    "<p>The dataset was created by using the command <code>git log --encoding=latin-1 --pretty=\"%at#%aN\"</code> in late 2017. The <code>latin-1</code> encoded text output was saved in a header-less CSV file. In this file, each row is a commit entry with the following information:</p>\n",
+    "<ul>\n",
+    "<li><code>timestamp</code>: the time of the commit as a UNIX timestamp in seconds since 1970-01-01 00:00:00 (Git log placeholder \"<code>%at</code>\")</li>\n",
+    "<li><code>author</code>: the name of the author that performed the commit (Git log placeholder \"<code>%aN</code>\")</li>\n",
+    "</ul>\n",
+    "<p>The columns are separated by the number sign <code>#</code>. The complete dataset is in the <code>datasets/</code> directory. It is a <code>gz</code>-compressed csv file named <code>git_log.gz</code>.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "dc": {
+     "key": "11"
+    },
+    "tags": [
+     "sample_code"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>author</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1502826583</td>\n",
+       "      <td>Linus Torvalds</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1501749089</td>\n",
+       "      <td>Adrian Hunter</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1501749088</td>\n",
+       "      <td>Adrian Hunter</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1501882480</td>\n",
+       "      <td>Kees Cook</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1497271395</td>\n",
+       "      <td>Rob Clark</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    timestamp          author\n",
+       "0  1502826583  Linus Torvalds\n",
+       "1  1501749089   Adrian Hunter\n",
+       "2  1501749088   Adrian Hunter\n",
+       "3  1501882480       Kees Cook\n",
+       "4  1497271395       Rob Clark"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Loading in the pandas module as 'pd'\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Reading in the log file\n",
+    "git_log = pd.read_csv(\"datasets/git_log.gz\", sep='#', encoding='latin-1',\n",
+    "                      header=None, names=[\"timestamp\", \"author\"])\n",
+    "\n",
+    "# Printing out the first 5 rows\n",
+    "git_log.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dc": {
+     "key": "18"
+    },
+    "deletable": false,
+    "editable": false,
+    "run_control": {
+     "frozen": true
+    },
+    "tags": [
+     "context"
+    ]
+   },
+   "source": [
+    "## 3. Getting an overview\n",
+    "<p>The dataset contains the information about every single code contribution (a \"commit\") to the Linux kernel over the last 13 years. We'll first take a look at the number of authors and their commits to the repository.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "dc": {
+     "key": "18"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17385 authors committed 699071 code changes.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# calculating number of commits\n",
+    "number_of_commits = git_log.timestamp.count()\n",
+    "\n",
+    "# calculating number of authors\n",
+    "number_of_authors = len(git_log.author.dropna().unique())\n",
+    "\n",
+    "# printing out the results\n",
+    "print(\"%s authors committed %s code changes.\" % (number_of_authors, number_of_commits))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dc": {
+     "key": "25"
+    },
+    "deletable": false,
+    "editable": false,
+    "run_control": {
+     "frozen": true
+    },
+    "tags": [
+     "context"
+    ]
+   },
+   "source": [
+    "## 4. Finding the TOP 10 contributors\n",
+    "<p>There are some very important people that changed the Linux kernel very often. To see if there are any bottlenecks, we take a look at the TOP 10 authors with the most commits.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "dc": {
+     "key": "25"
+    },
+    "tags": [
+     "sample_code"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Linus Torvalds           23361\n",
+       "David S. Miller           9106\n",
+       "Mark Brown                6802\n",
+       "Takashi Iwai              6209\n",
+       "Al Viro                   6006\n",
+       "H Hartley Sweeten         5938\n",
+       "Ingo Molnar               5344\n",
+       "Mauro Carvalho Chehab     5204\n",
+       "Arnd Bergmann             4890\n",
+       "Greg Kroah-Hartman        4580\n",
+       "Name: author, dtype: int64"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Identifying the top 10 authors\n",
+    "top_10_authors = git_log.author.value_counts(dropna=True)[0:10]\n",
+    "\n",
+    "# Listing contents of 'top_10_authors'\n",
+    "top_10_authors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dc": {
+     "key": "32"
+    },
+    "deletable": false,
+    "editable": false,
+    "run_control": {
+     "frozen": true
+    },
+    "tags": [
+     "context"
+    ]
+   },
+   "source": [
+    "## 5. Wrangling the data\n",
+    "<p>For our analysis, we want to visualize the contributions over time. For this, we use the information in the <code>timestamp</code> column to create a time series-based column.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "dc": {
+     "key": "32"
+    },
+    "tags": [
+     "sample_code"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "count                  699071\n",
+       "unique                 668448\n",
+       "top       2008-09-04 05:30:19\n",
+       "freq                       99\n",
+       "first     1970-01-01 00:00:01\n",
+       "last      2037-04-25 08:08:26\n",
+       "Name: timestamp, dtype: object"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# converting the timestamp column\n",
+    "git_log['timestamp'] = pd.to_datetime(git_log['timestamp'], unit='s')\n",
+    "\n",
+    "# summarizing the converted timestamp column\n",
+    "git_log.timestamp.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dc": {
+     "key": "39"
+    },
+    "deletable": false,
+    "editable": false,
+    "run_control": {
+     "frozen": true
+    },
+    "tags": [
+     "context"
+    ]
+   },
+   "source": [
+    "## 6. Treating wrong timestamps\n",
+    "<p>As we can see from the results above, some contributors had their operating system's time incorrectly set when they committed to the repository. We'll clean up the <code>timestamp</code> column by dropping the rows with the incorrect timestamps.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "dc": {
+     "key": "39"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tovalds's first timestamp was at 2005-04-16 22:20:36\n",
+      "The last timestamp before 2008 was at 2017-10-03 12:57:00\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "count                  698569\n",
+       "unique                 667977\n",
+       "top       2008-09-04 05:30:19\n",
+       "freq                       99\n",
+       "first     2005-04-16 22:20:36\n",
+       "last      2017-10-03 12:57:00\n",
+       "Name: timestamp, dtype: object"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# determining the first real commit timestamp\n",
+    "first_commit_timestamp = git_log[git_log['author']=='Linus Torvalds'].timestamp.min()\n",
+    "print(\"Tovalds's first timestamp was at\", first_commit_timestamp)\n",
+    "\n",
+    "# determining the last sensible commit timestamp\n",
+    "last_commit_timestamp = git_log[git_log['timestamp'] < '2018'].timestamp.max()\n",
+    "print(\"The last timestamp before 2008 was at\", last_commit_timestamp)\n",
+    "\n",
+    "# filtering out wrong timestamps\n",
+    "corrected_log = git_log[(git_log['timestamp'] >= first_commit_timestamp) &\n",
+    "                        (git_log['timestamp'] <= last_commit_timestamp)]\n",
+    "\n",
+    "# summarizing the corrected timestamp column\n",
+    "corrected_log['timestamp'].describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dc": {
+     "key": "46"
+    },
+    "deletable": false,
+    "editable": false,
+    "run_control": {
+     "frozen": true
+    },
+    "tags": [
+     "context"
+    ]
+   },
+   "source": [
+    "## 7. Grouping commits per year\n",
+    "<p>To find out how the development activity has increased over time, we'll group the commits by year and count them up.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "dc": {
+     "key": "46"
+    },
+    "tags": [
+     "sample_code"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Commits</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>timestamp</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2005-01-01</th>\n",
+       "      <td>16229</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2006-01-01</th>\n",
+       "      <td>29255</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2007-01-01</th>\n",
+       "      <td>33759</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2008-01-01</th>\n",
+       "      <td>48847</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2009-01-01</th>\n",
+       "      <td>52572</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            Commits\n",
+       "timestamp          \n",
+       "2005-01-01    16229\n",
+       "2006-01-01    29255\n",
+       "2007-01-01    33759\n",
+       "2008-01-01    48847\n",
+       "2009-01-01    52572"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Counting the no. commits per year\n",
+    "commits_per_year = corrected_log.groupby(\n",
+    "    pd.Grouper(\n",
+    "        key='timestamp',\n",
+    "        freq='AS'\n",
+    "        )\n",
+    "    ).count()\n",
+    "commits_per_year.columns = ['Commits']\n",
+    "# Listing the first rows\n",
+    "commits_per_year.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dc": {
+     "key": "53"
+    },
+    "deletable": false,
+    "editable": false,
+    "run_control": {
+     "frozen": true
+    },
+    "tags": [
+     "context"
+    ]
+   },
+   "source": [
+    "## 8. Visualizing the history of Linux\n",
+    "<p>Finally, we'll make a plot out of these counts to better see how the development effort on Linux has increased over the the last few years. </p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "dc": {
+     "key": "53"
+    },
+    "tags": [
+     "sample_code"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0, 0.5, 'Commits')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZEAAAEmCAYAAACj7q2aAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8li6FKAAAgAElEQVR4nO3de7xVdbnv8c9XCMUUQWWzDTSo6EKWpiul7JRpIaiFdcr0WHA8JJW6u+zdTqx2luXZ9Dpnp7Ez92EnCd0M3ZWUFyIvXU6hLNRENGN5QWALrATFtEz02X+M34zBcrKYDMaYizX4vl+v+ZpjPuM3xvP7wVrzWeOuiMDMzKyIPfq6A2Zm1n+5iJiZWWEuImZmVpiLiJmZFeYiYmZmhbmImJlZYS4iZhWTdKyk1X3djx0h6XpJU/u6H7brcxGx2pF0i6SNkvbs6770VxExKSLmAkj6n5J+1dd9sl2Ti4jViqTRwH8DAnhnn3bGbDfgImJ1MwVYDFwBbLU7RtIVki6VdK2kJyTdKumlufkh6cOSVkh6LLVVmvd5Sd/OtR2d2g9Mn8+UdG9a7wOSPtRqhyW9WtIiSRskrZP06RTfU9Ilkv4zvS5pbF01dpFJ+pSk9ZIekXSKpBMl/T6t69O5HJ+XdJWkb6c+LpP0cknnp+VXSZqQa3+LpA9KehXwb8AbJP1R0mNp/omS7knrWiPpk63/F1mduIhY3UwBvpNeJ0ga0WP+acAXgGFAF3BRj/knA68HXgucCpzQYt71adkhwJnAxZKO2N5CkvYFfgbcALwIeBlwY5r9GWA8cDhwGHAU8Nnc4n8L7AWMBD4H/DvwfuBIsq2xf5I0Jtf+HcC3yMZ+B7CQ7DtgJHAh8P969i8i7gU+DPwmIvaJiKFp1uXAhyJiX+BQ4KbtjdXqyUXEakPSm4AXA/MjYilwP/A/ejT7YUTcFhGbyQrN4T3mz4yIxyLiYeDmJvObiohrI+L+yPwc+CnZF/n2nAysjYh/iYg/R8QTEXFrmncGcGFErI+IbrLi94Hcss8AF0XEM8CVwIHAV9M6lgP3kBWfhl9GxMI09quA4Wm8jeVHSxpKa54BxkkaEhEbI+L2FpezmnERsTqZCvw0Iv6QPn+XHru0gLW56aeAfXZwflOSJklanHYjPQacSPalvj0HkxW7Zl4ErMx9XpliDY9GxLNp+k/pfV1u/p/Yuv895/2hyfItjRf472RjXCnp55Le0OJyVjMD+7oDZmWQNJhs99MASY1CsCcwVNJhEfHbnUzxJLB37vPf5nLvCfwH2a60ayLiGUk/AtTCeleR7WJr5j/JtqyWp8+HpFi7Pe9W3xGxBJgs6QXAucB8soJouxlviVhdnAI8C4wj2wV1OPAq4JdkX+47607gzZIOkbQfcH5u3iCygtUNbJY0CZjQZB3N/AQ4SNLH04H0fSUdneZ9D/ispOGSDiQ77vHtba6pOuuAUZIGAUgaJOkMSfulXWGbgOf6oF+2C3ARsbqYCnwzIh6OiLWNF/A14IzGWVRFRcQi4PvAXcBSsi//xrwngI+S/TW+kew4zIIW1/sE8Hayg95rgRXAW9PsLwGdKecy4PYUa7ebyLaG1kpq7Cr8APCQpE1kB97P6IN+2S5AfiiVmZkV5S0RMzMrzEXEzMwKcxExM7PCKi0ikj4habmkuyV9T9Jeksak2010Sfp+7oyPPdPnrjR/dG4956f4fZJOyMUnpliXpBlVjsXMzJ6vsiIiaSTZGSsdEXEoMIDsfPgvAxdHxMvIzmSZlhaZBmxM8YtTOySNS8u9GpgIfF3SAEkDgEuBSWSndZ6e2pqZWZtUfbHhQGCwpGfILtR6BDiOLbeimAt8HrgMmJymAa4GvpZufjcZuDIingYelNRFdg8hgK6IeABA0pWp7T29dejAAw+M0aNHlzE2M7PdwtKlS/8QEcObzausiETEGkn/F3iY7JYKPyU7v/6xdO8egNVkN38jva9Ky26W9DhwQIovzq06v8yqHvGjaULSdGA6wCGHHEJnZ+fODc7MbDciaeW25lW5O2sY2ZbBGLL7/byQbHdU20XE7IjoiIiO4cObFlMzMyugygPrbwMejIjudGuEHwDHkN3LqLEFNApYk6bXkO69k+bvBzyaj/dYZltxMzNrkyqLyMPAeEl7p2Mbx5Mdr7gZeE9qMxW4Jk0vYMsdV98D3BTZ5fQLgNPS2VtjgLHAbcASYGw622sQ2cH3lm41YWZm5ajymMitkq4mu9/PZrKH4MwGrgWulPSlFLs8LXI58K104HwD6c6mEbFc0nyyArQZOKdx+2pJ55I9WGcAMCc9Q8HMzNpkt7t3VkdHR/jAuplZ6yQtjYiOZvN8xbqZmRXmImJmZoW5iJiZWWF+PK6ZWRuNnnHtDi/z0MyTKuhJObwlYmZmhbmImJlZYd6dZWa7vHbtAtrRPLvybqZ28ZaImZkV5iJiZmaFuYiYmVlhLiJmZlaYi4iZmRXmImJmZoW5iJiZWWEuImZmVpiLiJmZFeYiYmZmhbmImJlZYZUVEUmvkHRn7rVJ0scl7S9pkaQV6X1Yai9JsyR1SbpL0hG5dU1N7VdImpqLHylpWVpmliRVNR4zM3u+ym7AGBH3AYcDSBoArAF+CMwAboyImZJmpM/nAZOAsel1NHAZcLSk/YELgA4ggKWSFkTExtTmLOBW4DpgInB9VWMys63V7dkYtuPatTvreOD+iFgJTAbmpvhc4JQ0PRmYF5nFwFBJBwEnAIsiYkMqHIuAiWnekIhYHBEBzMuty8zM2qBdReQ04HtpekREPJKm1wIj0vRIYFVumdUp1lt8dZP480iaLqlTUmd3d/fOjMPMzHIqLyKSBgHvBK7qOS9tQUTVfYiI2RHREREdw4cPrzqdmdluox1bIpOA2yNiXfq8Lu2KIr2vT/E1wMG55UalWG/xUU3iZmbWJu0oIqezZVcWwAKgcYbVVOCaXHxKOktrPPB42u21EJggaVg6k2sCsDDN2yRpfDora0puXWZm1gaVPh5X0guBtwMfyoVnAvMlTQNWAqem+HXAiUAX8BRwJkBEbJD0RWBJandhRGxI02cDVwCDyc7K8plZZmZtVGkRiYgngQN6xB4lO1urZ9sAztnGeuYAc5rEO4FDS+msmZntMF+xbmZmhbmImJlZYS4iZmZWmIuImZkV5iJiZmaFuYiYmVlhLiJmZlZYpdeJmFnf8C3arV28JWJmZoW5iJiZWWEuImZmVpiLiJmZFeYiYmZmhbmImJlZYS4iZmZWmIuImZkV5iJiZmaFuYiYmVlhlRYRSUMlXS3pd5LulfQGSftLWiRpRXofltpK0ixJXZLuknREbj1TU/sVkqbm4kdKWpaWmSVJVY7HzMy2VvWWyFeBGyLilcBhwL3ADODGiBgL3Jg+A0wCxqbXdOAyAEn7AxcARwNHARc0Ck9qc1ZuuYkVj8fMzHIqKyKS9gPeDFwOEBF/iYjHgMnA3NRsLnBKmp4MzIvMYmCopIOAE4BFEbEhIjYCi4CJad6QiFgcEQHMy63LzMzaoMotkTFAN/BNSXdI+oakFwIjIuKR1GYtMCJNjwRW5ZZfnWK9xVc3iT+PpOmSOiV1dnd37+SwzMysocoiMhA4ArgsIl4HPMmWXVcApC2IqLAPjTyzI6IjIjqGDx9edTozs91GlUVkNbA6Im5Nn68mKyrr0q4o0vv6NH8NcHBu+VEp1lt8VJO4mZm1SWVFJCLWAqskvSKFjgfuARYAjTOspgLXpOkFwJR0ltZ44PG022shMEHSsHRAfQKwMM3bJGl8OitrSm5dZmbWBlU/2fDvgO9IGgQ8AJxJVrjmS5oGrAROTW2vA04EuoCnUlsiYoOkLwJLUrsLI2JDmj4buAIYDFyfXmZm1iaVFpGIuBPoaDLr+CZtAzhnG+uZA8xpEu8EDt3JbpqZWUG+Yt3MzApzETEzs8JcRMzMrDAXETMzK6zqs7PMrIfRM67dofYPzTypop6Y7TxviZiZWWEuImZmVpiLiJmZFeYiYmZmhbmImJlZYS4iZmZWmIuImZkV5iJiZmaFuYiYmVlhvmLddnk7eoU3+Cpvs3bxloiZmRXmImJmZoW5iJiZWWGVFhFJD0laJulOSZ0ptr+kRZJWpPdhKS5JsyR1SbpL0hG59UxN7VdImpqLH5nW35WWVZXjMTOzrbVjS+StEXF4RDSetT4DuDEixgI3ps8Ak4Cx6TUduAyyogNcABwNHAVc0Cg8qc1ZueUmVj8cMzNr6IvdWZOBuWl6LnBKLj4vMouBoZIOAk4AFkXEhojYCCwCJqZ5QyJicUQEMC+3LjMza4Oqi0gAP5W0VNL0FBsREY+k6bXAiDQ9EliVW3Z1ivUWX90k/jySpkvqlNTZ3d29M+MxM7Ocqq8TeVNErJH0N8AiSb/Lz4yIkBQV94GImA3MBujo6Kg8n/VPvh7FbMdVuiUSEWvS+3rgh2THNNalXVGk9/Wp+Rrg4Nzio1Kst/ioJnEzM2uTyoqIpBdK2rcxDUwA7gYWAI0zrKYC16TpBcCUdJbWeODxtNtrITBB0rB0QH0CsDDN2yRpfDora0puXWZm1gZV7s4aAfwwnXU7EPhuRNwgaQkwX9I0YCVwamp/HXAi0AU8BZwJEBEbJH0RWJLaXRgRG9L02cAVwGDg+vSyNvHuHzOrrIhExAPAYU3ijwLHN4kHcM421jUHmNMk3gkcutOdNTOzQnzFupmZFdZSEZF0TDqugaT3S/qKpBdX2zUzM9vVtbo76zLgMEmHAf8AfIPs4r63VNUxMzMrrl3HLFvdnbU5HbOYDHwtIi4F9t3hbGZmViutbok8Iel84P3AmyXtAbygum6ZmVl/0OqWyPuAp4FpEbGW7MK+/1NZr8zMrF9odUvkExFxXuNDRDws6dUV9cnMzPqJVrdE3t4kNqnMjpiZWf/T65aIpI+QXRX+Ekl35WbtC/y6yo6Zmdmub3u7s75LdiuRf2bLw6MAnsjdesTMzHZT2ysiEREPSXre7Ugk7e9CYma2e2tlS+RkYCnZA6byzzAP4CUV9cvMzPqBXotIRJyc3se0pztmZtaftHwXX0mvBUbnl4mIH1TQJzMz6ydaKiKS5gCvBZYDz6VwAC4iZma7sVa3RMZHxLhKe2JmZv1Oqxcb/kaSi4iZmW2l1S2ReWSFZC3ZPbREdvrvayvrmZmZ7fJa3RK5HPgAMBF4B9lpv+9oZUFJAyTdIekn6fMYSbdK6pL0fUmDUnzP9LkrzR+dW8f5KX6fpBNy8Ykp1iVpRs/cZmZWrVaLSHdELIiIByNiZePV4rIfA+7Nff4ycHFEvAzYCExL8WnAxhS/OLUj7UY7DXg1WRH7eipMA4BLye7hNQ443bvczMzaq9Uicoek70o6XdK7G6/tLSRpFHAS2ZMQkSTgOODq1GQucEqanpw+k+Yfn9pPBq6MiKcj4kGgCzgqvboi4oGI+AtwZWprZmZt0uoxkcFkx0Im5GKtnOJ7CfAptjwF8QDgsYjYnD6vBkam6ZHAKoCI2Czp8dR+JLA4t878Mqt6xI9u1glJ04HpAIcccsh2umxmZq1qqYhExJk7umJJJwPrI2KppGN3dPkyRcRsYDZAR0dH9GVfzMzqpNWLDccAf8fzr1h/Zy+LHQO8U9KJwF7AEOCrwFBJA9PWyChgTWq/BjgYWC1pILAf8Ggu3pBfZltxMzNrg1aPifwIeAj4V+Bfcq9tiojzI2JURIwmOzB+U0ScAdwMvCc1mwpck6YXpM+k+TdFRKT4aensrTHAWOA2YAkwNp3tNSjlWNDieMzMrAStHhP5c0TMKinnecCVkr4E3EF2+jDp/VuSuoANZEWBiFguaT5wD7AZOCcingWQdC6wEBgAzImI5SX10czMWtBqEfmqpAuAn5IdYAcgIm5vZeGIuAW4JU0/QHZmVc82fwbeu43lLwIuahK/DriulT6YmVn5Wi0iryG72PA4tr4B43FVdMrMzPqHVovIe4GXpOsxzMzMgNYPrN8NDK2yI2Zm1v+0uiUyFPidpCVsfUykt1N8zcys5lotIhdU2gszM+uXWr1i/eeSRgCvT6HbImJ9dd0yM7P+oKVjIpJOJbvA773AqcCtkt7T+1JmZlZ3re7O+gzw+sbWh6ThwM/YcjdeMzPbDbV6dtYePXZfPboDy5qZWU21uiVyg6SFwPfS5/fhK8XNzHZ7vRYRSS8DRkTEP6aHUL0pzfoN8J2qO2dmZru27W2JXAKcDxARPyA9hErSa9K8lp6zbu03esa1O9T+oZknVdQTM6uz7R3XGBERy3oGU2x0JT0yM7N+Y3tFpLdbnQwusyNmZtb/bK+IdEo6q2dQ0geBpdV0yczM+ovtHRP5OPBDSWewpWh0AIOAd1XZMTMz2/X1WkQiYh3wRklvBQ5N4Wsj4qbKe2ZmZru8Vu+ddTPZs9HNzMz+qrKrziXtJek2Sb+VtFzSF1J8jKRbJXVJ+r6kQSm+Z/rcleaPzq3r/BS/T9IJufjEFOuSNKOqsZiZWXNV3rrkaeC4iDgMOByYKGk88GXg4oh4GbARmJbaTwM2pvjFqR2SxgGnAa8GJgJflzRA0gDgUmASMA44PbU1M7M2qayIROaP6eML0qvxXPbGjRvnAqek6cnpM2n+8ZKU4ldGxNMR8SDQBRyVXl0R8UB6bO+Vqa2ZmbVJpTdRTFsMdwLrgUXA/cBjEbE5NVkNjEzTI4FVAGn+48AB+XiPZbYVb9aP6ZI6JXV2d3eXMTQzM6PiIhIRz0bE4cAosi2HV1aZr5d+zI6IjojoGD58eF90wcysllq9i+9OiYjHJN0MvAEYKmlg2toYBaxJzdYABwOrJQ0E9iO75Xwj3pBfZlvxXdaO3tMKfF8rM9t1VXl21nBJQ9P0YODtwL1kpwo3noo4FbgmTS9In0nzb4qISPHT0tlbY4CxZE9ZXAKMTWd7DSI7+L6gqvGYmdnzVbklchAwN51FtQcwPyJ+Iuke4EpJXwLuAC5P7S8HviWpC9hAVhSIiOWS5gP3AJuBcyLiWQBJ5wILgQHAnIhYXuF4zMysh8qKSETcBbyuSfwBsuMjPeN/JnuGe7N1XQRc1CR+HX44lplZn/Ejbs3MrDAXETMzK8xFxMzMCnMRMTOzwlxEzMysMBcRMzMrzEXEzMwKcxExM7PCXETMzKwwFxEzMyvMRcTMzApzETEzs8JcRMzMrDAXETMzK8xFxMzMCnMRMTOzwlxEzMysMBcRMzMrrLIiIulgSTdLukfSckkfS/H9JS2StCK9D0txSZolqUvSXZKOyK1ramq/QtLUXPxIScvSMrMkqarxmJnZ81W5JbIZ+IeIGAeMB86RNA6YAdwYEWOBG9NngEnA2PSaDlwGWdEBLgCOJns2+wWNwpPanJVbbmKF4zEzsx4qKyIR8UhE3J6mnwDuBUYCk4G5qdlc4JQ0PRmYF5nFwFBJBwEnAIsiYkNEbAQWARPTvCERsTgiApiXW5eZmbVBW46JSBoNvA64FRgREY+kWWuBEWl6JLAqt9jqFOstvrpJvFn+6ZI6JXV2d3fv1FjMzGyLyouIpH2A/wA+HhGb8vPSFkRU3YeImB0RHRHRMXz48KrTmZntNiotIpJeQFZAvhMRP0jhdWlXFOl9fYqvAQ7OLT4qxXqLj2oSNzOzNqny7CwBlwP3RsRXcrMWAI0zrKYC1+TiU9JZWuOBx9Nur4XABEnD0gH1CcDCNG+TpPEp15TcuszMrA0GVrjuY4APAMsk3ZlinwZmAvMlTQNWAqemedcBJwJdwFPAmQARsUHSF4Elqd2FEbEhTZ8NXAEMBq5PLzMza5PKikhE/ArY1nUbxzdpH8A521jXHGBOk3gncOhOdNPMzHaCr1g3M7PCXETMzKwwFxEzMyvMRcTMzApzETEzs8KqPMW3Xxk949odXuahmSdV0BMzs/7DWyJmZlaYi4iZmRXmImJmZoW5iJiZWWEuImZmVpiLiJmZFeYiYmZmhbmImJlZYS4iZmZWmIuImZkV5iJiZmaFuYiYmVlhlRURSXMkrZd0dy62v6RFklak92EpLkmzJHVJukvSEbllpqb2KyRNzcWPlLQsLTNL0rYexWtmZhWpckvkCmBij9gM4MaIGAvcmD4DTALGptd04DLIig5wAXA0cBRwQaPwpDZn5ZbrmcvMzCpWWRGJiF8AG3qEJwNz0/Rc4JRcfF5kFgNDJR0EnAAsiogNEbERWARMTPOGRMTiiAhgXm5dZmbWJu0+JjIiIh5J02uBEWl6JLAq1251ivUWX90k3pSk6ZI6JXV2d3fv3AjMzOyv+uzAetqCiDblmh0RHRHRMXz48HakNDPbLbS7iKxLu6JI7+tTfA1wcK7dqBTrLT6qSdzMzNqo3UVkAdA4w2oqcE0uPiWdpTUeeDzt9loITJA0LB1QnwAsTPM2SRqfzsqakluXmZm1SWXPWJf0PeBY4EBJq8nOspoJzJc0DVgJnJqaXwecCHQBTwFnAkTEBklfBJakdhdGRONg/dlkZ4ANBq5PLzMza6PKikhEnL6NWcc3aRvAOdtYzxxgTpN4J3DozvTRzMx2jq9YNzOzwlxEzMysMBcRMzMrzEXEzMwKcxExM7PCXETMzKwwFxEzMyvMRcTMzApzETEzs8JcRMzMrDAXETMzK8xFxMzMCnMRMTOzwlxEzMysMBcRMzMrzEXEzMwKcxExM7PCXETMzKywfl9EJE2UdJ+kLkkz+ro/Zma7k35dRCQNAC4FJgHjgNMljevbXpmZ7T76dREBjgK6IuKBiPgLcCUwuY/7ZGa221BE9HUfCpP0HmBiRHwwff4AcHREnNuj3XRgevr4CuC+HUhzIPCHErrrPP0zh/Psujmcp305XhwRw5vNGLjz/dn1RcRsYHaRZSV1RkRHyV1ynn6Sw3l23RzOs2vk6O+7s9YAB+c+j0oxMzNrg/5eRJYAYyWNkTQIOA1Y0Md9MjPbbfTr3VkRsVnSucBCYAAwJyKWl5ym0G4w52lLnjqNpW556jSWuuUpNUe/PrBuZmZ9q7/vzjIzsz7kImJmZoW5iJiZWWEuImZmVpiLSC/SqcPvlvTKktd7iKS90rQknSnpXyV9RFJpZ8xJemcjT5UkvVnSK9L0MZI+KemkCvLsI+k9kj4h6aPp5pul/wxLeqWk8yTNSq/zJL2q7Dy95D+zxHW9UtLxkvbpEZ9YVo60vqMkvT5Nj5P095JOLDPHNvLOa0OON6XxTChxnUdLGpKmB0v6gqQfS/qypP1KzPNRSQdvv+VO5PDZWVtI+lFEnJKmJwOXALcAbwT+OSKuKCnP3cBREfGUpC8DLwV+BBwHEBH/q6Q8fwKeBK4HvgcsjIhny1h3LsclZPcwG0h2qvXxKd9bgDsi4h9LynMq8EngLuCtwK/J/gh6DXBGRCwrKc95wOlk92FbncKjyK5BujIiZpaRZzt9eDgiDilhPR8FzgHuBQ4HPhYR16R5t0fEETubI63rArKboA4EFgFHAzcDbyf7mbuopDw9rwET2c/CTQAR8c6S8twWEUel6bPI/g1/CEwAflzGz4Ck5cBh6TKF2cBTwNVkvz+HRcS7dzZHyvM42XfA/WTfAVdFRHcZ6/6riPArvci+9BrTvwbGpOkDgd+WmOee3PRSYI/c5zLz3AEMA84CbgTWAf8GvKXEHMvJfpn3BjYCe6f4C4C7S8xzV27dB5J9OQG8Fvh1iXl+D7ygSXwQsKLk8TR7LQOeLinHMmCfND0a6CQrJFv9rJeUZ0D6GdgEDEnxwcBdJea5Hfg2cCzZHynHAo+k6beUmCf/PbAEGJ6mXwgsKynHvflx9Zh3Z5ljIftjawJwOdAN3ABMBfYtI4d3Z20tv1k2MCIeBIiIPwDPlZhnlaTj0vRDpFu3SDqgxBwAEREbI+LfI+J44DDgHmCmpFUl5gi2/Ps0/g2fo9zdpQL+lKafBP4mJb8LGFJinueAFzWJH0S5PwMjgCnAO5q8Hi0pxx4R8UeAiHiI7Et3kqSvkP17lmVzRDwbEU8B90fEppTzT5T7b9ZB9kfXZ4DHI+IW4E8R8fOI+HmJefaQNCz9PirSX+4R8SSwuaQcd+d2W/5WUgeApJcDz5SUA7Lfz+ci4qcRMY3sZ/vrwETggTIS9Osr1itwmKRNZL9ge0o6KCIeSbdUGVBing8C8yR9HngcuFPSncBQ4O9LzLPVF0VErAVmAbMkvbikHNdK+iWwF/ANYL6kxWR/Hf6ipBwA1wE3SPoF2S/AVQCS9qfcL8SPAzdKWgE0Cu0hwMuAc7e51I77CdlWwp09Z0i6paQc6yQd3sgREX+UdDIwh2w3YFn+ImnvVESObATTvv3SikhEPAdcLOmq9L6Oar7D9iMrVgIi9z2wD+X9rH0Q+Kqkz5LdUfc36Q+7VWleWXp+BzxDdmuoBZL2LiVB2uSxXkgaCrwqIn5T8npfBbyc7BdhNbAk/aKUtf5j019rlZL0BrK/eBZLeinwLuBh4OqSx3Mi2cPHfhsRi1JsD7LdT0+XmGcPsuM8I1NoDdn/TanHk6omaRTZVsLaJvOOiYj/X1KePZv9+0s6EDgoSjpe1WT9JwHHRMSnq1h/k3x7AyMaeyhKWucQYAzpOyAi1pW17rT+l0fE78tc5/NyuIg8n6QR5L5Ayv6PrWOeOo2ll9z7NHYP9fc8dRpL3fL0t7G4iORIeh1wGdnmbOOW8qOAx4CPRMQdJeU5nOwAd7M8Z0fE7f0lT53G0kIfSjlralfIU6ex1C1PfxuLj4ls7ZvAhyLi1nxQ0njgCrID02W4opc83+xnedqRo215JG3rmJSAfbYxb5fMU6ex1C1Pncbis7O29sKeX1IAEbGY7PQ+5+mbHO3M87/JTovet8drH8r9fWlHnjqNpW55ajMWb4ls7XpJ1wLz2HJmzsFkp2Le4Dx9lqOdeW4HfhQRS3vOkFTmWTPtyFOnsdQtT23G4mMiPUiaBExm6zNzFkTEdc7TdznalUfZ7Vs2RJOreiWNKOtAfjvy1GksdctTq7G4iJiZWVE+JpIjaT9JMyXdK2mDpEfT9Mx0rYjz9EGOPsrzu/6ep05jqVueOo3FRWRr88nu//TWiNg/Ig4gu8HbY2me8/RNjr7Ic2yPPBv7YZCHwuUAAAKtSURBVJ46jaVueeozlijpRl91eAH3FZm3O+ep01jqlqdOY6lbnjqNxVsiW1sp6VPKrooGsoNPym4PXtYNC+uWp05jqVueOo2lbnlqMxYXka29DzgA+LmkjZI2kD1PZH/gVOfpsxzOs+vmcJ5dN0d78pS12VSXF/BK4G2k5zDk4hOdp/5jqVueOo2lbnnqMpbSOlqHF/BR4D6ypww+BEzOzbvdeeo9lrrlqdNY6panVmMpq7N1eNHeJ8HVIk+dxlK3PHUaS93y1Gksvu3J1rZ6EpykY4GrlT3AqcwHH9UpT53GUrc8dRpL3fLUZiw+sL61dcpuOQ5kT4IDTiZ7pneZT4KrU546jaVueeo0lrrlqc1YfNuTHLXvSXC1yVOnsdQtT53GUrc8tRqLi4iZmRXl3VlmZlaYi4iZmRXmImJWIWV+pexZKI3YeyWV+SAtsz7jYyJmFZN0KHAV8Dqyp4neQXa18P07sc6BEbG5pC6aFeYtEbOKRcTdwI+B84DPAfMi4n5JUyXdJulOSV+XtAeApNmSOiUtl/S5xnokrVb2HIg7gHf1yWDMevDFhmbt8QWy513/BehIWyfvAt4YEZslzQZOA74LzIiIDZIGAjdLujoi7knrWR8Rr+uLAZg14yJi1gYR8aSk7wN/jIinJb0NeD3QKQlgMFtuzX26pGlkv58vAsYBjSLy/fb23Kx3LiJm7fNcekF2y4k5EfFP+QaSxgIfA46KiMckfRvYK9fkybb01KxFPiZi1jd+Bpwq6UAASQdIOgQYAjwBbJJ0EHBCH/bRbLu8JWLWByJimaQvAD9LB9SfAT5MdpfVe4DfASuBUm5/YVYVn+JrZmaFeXeWmZkV5iJiZmaFuYiYmVlhLiJmZlaYi4iZmRXmImJmZoW5iJiZWWEuImZmVth/AWjgQPqVcutHAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Setting up plotting in Jupyter notebooks\n",
+    "%matplotlib inline\n",
+    "\n",
+    "commits_per_year['year_only'] = commits_per_year.index.year\n",
+    "# plot the data\n",
+    "ax = commits_per_year.plot(x='year_only', kind='bar',\n",
+    "                          legend=None, title=\"Annual commits\")\n",
+    "ax.set_xlabel('Year')\n",
+    "ax.set_ylabel('Commits')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dc": {
+     "key": "60"
+    },
+    "deletable": false,
+    "editable": false,
+    "run_control": {
+     "frozen": true
+    },
+    "tags": [
+     "context"
+    ]
+   },
+   "source": [
+    "## 9.  Conclusion\n",
+    "<p>Thanks to the solid foundation and caretaking of Linux Torvalds, many other developers are now able to contribute to the Linux kernel as well. There is no decrease of development activity at sight!</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "dc": {
+     "key": "60"
+    },
+    "tags": [
+     "sample_code"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# calculating or setting the year with the most commits to Linux\n",
+    "year_with_most_commits = commits_per_year['Commits'].idxmax().year"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The original git_log.gz file was downloaded using DataCamps user interface. This zips the gzip and somehow brakes it. The intact data can be retrieved from the embedded jupyter-notebook: file > open > git_log.gz.